### PR TITLE
In chapter 12, fix the references to figure 2

### DIFF
--- a/book/CH12_HyperviewAMobileHypermedia.adoc
+++ b/book/CH12_HyperviewAMobileHypermedia.adoc
@@ -179,9 +179,9 @@ And there's definitely no widely distributed "`HXML browser`".
 So how can a developer deliver a Hypermedia mobile app using HXML?
 Well, unlike on the web, the mobile developer must provide both the backend to serve HXML, and a mobile client app to render those HXML responses.
 
-[#figure-6-1, reftext="Figure {chapter}.{counter:figure}"]
+[#figure-6-2, reftext="Figure {chapter}.{counter:figure}"]
 .One HXML server, one HXML client
-image::figure_6_1.png[]
+image::figure_6_2.png[]
 
 It would be a lot to ask from developers to write their own HXML client.
 That's why Hyperview provides an open-source client library, written in React Native.


### PR DESCRIPTION
This figure had been the same as the figure above it, which is not intended.

1. Before: https://hypermedia.systems/book/hyperview-a-mobile-hypermedia/#figure-6-1
2. After: https://deploy-preview-5--hypermedia-systems.netlify.app/book/hyperview-a-mobile-hypermedia/#figure-6-2