### PR TITLE
Fix grammar by replacing “it’s” with “its”

### DIFF
--- a/book/CH05_ExtendingHTMLAsHypermedia.adoc
+++ b/book/CH05_ExtendingHTMLAsHypermedia.adoc
@@ -582,7 +582,7 @@ OK, so this filter limits the keyup events that will trigger the request to only
 the problem that, as it stands, only `keyup` events _within_ the button will trigger the request.
 
 If you are not familiar with the JavaScript event bubbling model: events typically "`bubble`" up to parent elements.  So an
-event like `keyup` will be triggered first on the focused element, and then on it's parent (enclosing) element, and so
+event like `keyup` will be triggered first on the focused element, and then on its parent (enclosing) element, and so
 on, until it reaches the top level `document` object that is the root of all other elements.
 
 To support a global keyboard shortcut that works regardless of what element has focus, we will take advantage of

--- a/book/CH06_htmxPatterns.adoc
+++ b/book/CH06_htmxPatterns.adoc
@@ -21,7 +21,7 @@ redirect us to the source of the latest version of the library.
 We can save the content from this URL into the `static/js/htmx.js` file in our project.
 
 You can, of course, use a more sophisticated JavaScript package manager such as Node Package Manager (NPM) or yarn to install
-htmx.  You do this by referring to it's package name, `htmx.org`, in the manner appropriate for your tool.  However,
+htmx.  You do this by referring to its package name, `htmx.org`, in the manner appropriate for your tool.  However,
 htmx is very small (approximately 12kb when compressed and zipped) and is dependency free, so using it does not require
 an elaborate mechanism or build tool.
 

--- a/book/CH08_ADynamicArchiveUIWithhtmx.adoc
+++ b/book/CH08_ADynamicArchiveUIWithhtmx.adoc
@@ -521,7 +521,7 @@ of the _existing_ element.  CSS transitions, unfortunately, only apply when the 
 not when the element is replaced.  This is a reason why pure HTML-based applications feel jerky and unpolished when compared
 with their SPA counterparts: it isn't possible to use CSS transitions without using JavaScript.
 
-Very unfortunate, but htmx rectifies this situation with it's swapping model.  Let's look at how.
+Very unfortunate, but htmx rectifies this situation with its swapping model.  Let's look at how.
 
 === The "`Settling`" Step in htmx
 

--- a/book/CH10_ScriptingInAHypermediaApplication.adoc
+++ b/book/CH10_ScriptingInAHypermediaApplication.adoc
@@ -864,7 +864,7 @@ to see if there are any selected contacts, quite easily:
 
 The next step is to ensure that toggling a checkbox for a given contact adds (or removes) a given contact's id from the
 `selected` property.  To do this, we will need to use a new Alpine attribute, `x-model`.  The `x-model` attribute allows
-you to _bind_ a given element to some underlying data, or it's "model".
+you to _bind_ a given element to some underlying data, or its "model".
 
 In this case, we want to bind the value of the checkbox inputs to the `selected` property.  This is how we do this:
 

--- a/book/CH15_Conclusion.adoc
+++ b/book/CH15_Conclusion.adoc
@@ -29,7 +29,7 @@ JavaScript, but using only hypermedia concepts.
 The Hypermedia Driven Application approach is not right for every application (after all, no approach is right for
 _every_ application) but, for many applications, the increased flexibility and simplicity of hypermedia can be a huge
 benefit.  And, even if your application wouldn't benefit from this approach, it is at least worthwhile to _understand_
-the approach, it's strengths and weaknesses, and how it differs from the approach you are taking.  The original web
+the approach, its strengths and weaknesses, and how it differs from the approach you are taking.  The original web
 grew faster than any distributed system in history, and it is worth understanding the underlying technologies that
 made that growth possible.
 


### PR DESCRIPTION
I reviewed all usages of “it’s” and “its” and ensured they were correct. No usages of “its” needed to be changed to “it’s”.