### PR TITLE
Fix "Entire book in one page" so that chapter 9 is not missing

### DIFF
--- a/book/HypermediaSystems.adoc
+++ b/book/HypermediaSystems.adoc
@@ -27,7 +27,7 @@ include::book/CH05_ExtendingHTMLAsHypermedia.adoc[leveloffset=1]
 include::book/CH06_htmxPatterns.adoc[leveloffset=1]
 include::book/CH07_MorehtmxPatterns.adoc[leveloffset=1]
 include::book/CH08_ADynamicArchiveUIWithhtmx.adoc[leveloffset=1]
-include::book/CH09_TricksOfThehtmxMasters.adoc.adoc[leveloffset=1]
+include::book/CH09_TricksOfThehtmxMasters.adoc[leveloffset=1]
 include::book/CH10_ScriptingInAHypermediaApplication.adoc[leveloffset=1]
 include::book/CH11_JSONDataAPIs.adoc[leveloffset=1]
 


### PR DESCRIPTION
[This page](https://hypermedia.systems/book/hypermedia-systems/) currently shows:
```
Unresolved directive in HypermediaSystems.adoc - include::book/CH09_TricksOfThehtmxMasters.adoc.adoc[leveloffset=1] :leveloffset: 1
```

At the end of chapter 8.