### PR TITLE
fix title tag to reflect book name

### DIFF
--- a/www/_includes/layout.njk
+++ b/www/_includes/layout.njk
@@ -3,7 +3,7 @@
 <head>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
-    <title>Building Hypermedia Systems</title>
+    <title>Hypermedia Systems</title>
     <link rel="preconnect" href="https://fonts.bunny.net">
     <link href="https://fonts.bunny.net/css?family=merriweather:400,400i,700,700i|merriweather-sans:400,400i,700,700i" rel="stylesheet" />
     <link rel="stylesheet" href="https://the.missing.style/v1.0.8/missing.css">


### PR DESCRIPTION
While testing the book's search engine appearance, I noticed the old title was still in the `<title>` tag of the page:
<img width="627" alt="Screen Shot 2023-01-12 at 11 08 43 AM" src="https://user-images.githubusercontent.com/1034502/212159127-7a989f00-06b9-47fc-afd5-066c80752419.png">

I'm pretty sure this is an oversight, but checking just in case this was intentional.
