### PR TITLE
Fix chapter 4 filename in HypermediaSystems.adoc

### DIFF
--- a/book/HypermediaSystems.adoc
+++ b/book/HypermediaSystems.adoc
@@ -34,7 +34,7 @@ include::book/CH03_BuildingASimpleWebApplication.adoc[leveloffset=1]
 
 = Hypermedia-Driven Web Applications With htmx
 
-include::book/CH05_ExtendingHTMLAsHypermedia.adoc[leveloffset=1]
+include::book/CH04_ExtendingHTMLAsHypermedia.adoc[leveloffset=1]
 include::book/CH05_htmxPatterns.adoc[leveloffset=1]
 include::book/CH06_MorehtmxPatterns.adoc[leveloffset=1]
 include::book/CH07_ADynamicArchiveUIWithhtmx.adoc[leveloffset=1]


### PR DESCRIPTION
The "[Entire book in one page](https://hypermedia.systems/book/hypermedia-systems/)" page has an error instead of [Part II](https://hypermedia.systems/book/hypermedia-systems/#_hypermedia_driven_web_applications_with_htmx). This fixes the error.

Tested by running `deno task serve` and verifying that served site includes Part II in both the table of contents and the page content below it.