### PR TITLE
Strip tags from doc title (Fixes #87)

### DIFF
--- a/www/_includes/layout.njk
+++ b/www/_includes/layout.njk
@@ -4,7 +4,7 @@
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
 
-    <title>{{ title | d("Hypermedia Systems") | safe }}</title>
+    <title>{{ title | d("Hypermedia Systems") | striptags | safe }}</title>
     <link rel="preconnect" href="https://fonts.bunny.net">
     {# <link href="https://fonts.bunny.net/css?family=literata:400,400i,700,700i|merriweather-sans:400,400i,700,700i" rel="stylesheet" /> #}
     <link rel="stylesheet" href="https://unpkg.com/missing.css@1.0.12/dist/missing.min.css">


### PR DESCRIPTION
This strips the HTML tags from the page title on the 'Entire book in one page' and 'Foreword' pages.

Still falls back to default if no title provided.