### PR TITLE
Fix h4 URL typo for trailing /edit

### DIFF
--- a/book/CH03_BuildingASimpleWebApplication.adoc
+++ b/book/CH03_BuildingASimpleWebApplication.adoc
@@ -782,7 +782,7 @@ drawbacks (it is not nearly as isolated as client-side components).
 Overall, a properly factored server-side hypermedia application can be extremely DRY.
 ****
 
-==== Handling the post to /contacts/<contact_id>
+==== Handling the post to /contacts/<contact_id>/edit
 
 Next we need to handle the HTTP `POST` request that the form in our `edit.html` template submits.  We will declare
 another route that handles the same path as the `GET` above.


### PR DESCRIPTION
Fixed obvious typo

```html
<button 
  hx-post="/merge"
  hx-confirm="First person to make it this far in the book"
  hx-vals='{ "sarcasm-level": "😅" }'>
merge me
</button>
```

😉