### PR TITLE
Fix argument typo in CH09_ScriptingInAHypermediaApplication.adoc

### DIFF
--- a/book/CH09_ScriptingInAHypermediaApplication.adoc
+++ b/book/CH09_ScriptingInAHypermediaApplication.adoc
@@ -541,11 +541,11 @@ overflow menu when htmx loads new content.
 ----
 
 function overflowMenu(subtree = document) {
-  document.querySelectorAll("[data-overflow-menu]").forEach(menuRoot => { <1>
+  subtree.querySelectorAll("[data-overflow-menu]").forEach(menuRoot => { <1>
     const
-    button = menuRoot.querySelector("[aria-haspopup]"), <2>
-    menu = menuRoot.querySelector("[role=menu]"), <2>
-    items = [...menu.querySelectorAll("[role=menuitem]")]; <3>
+      button = menuRoot.querySelector("[aria-haspopup]"), <2>
+      menu = menuRoot.querySelector("[role=menu]"), <2>
+      items = [...menu.querySelectorAll("[role=menuitem]")]; <3>
   });
 }
 


### PR DESCRIPTION
The querySelectorAll function should be called from **subtree argument** not directly from **document** object.