### PR TITLE
Fix code block rendering in CH08_TricksOfThehtmxMasters.adoc

### DIFF
--- a/book/CH08_TricksOfThehtmxMasters.adoc
+++ b/book/CH08_TricksOfThehtmxMasters.adoc
@@ -276,6 +276,7 @@ both buttons in a `div` and eliminate the redundant `hx-target` specification by
 Here is our updated code:
 
 (((hx-sync, example)))
+
 .Syncing two buttons
 [source, html]
 ----


### PR DESCRIPTION
The title "Syncing two buttons" didn't render well. The dot was visible.

# Before

![image](https://github.com/bigskysoftware/hypermedia-systems/assets/20454870/ac7101c1-11ec-4e5c-b5b7-342ad9c1566c)

# After

![image](https://github.com/bigskysoftware/hypermedia-systems/assets/20454870/9d0de8e8-7664-4bca-b3e2-c3acfae1a870)
