### PR TITLE
Fix rendering of "JSON Data APIs vs JSON REST APIs" title

### DIFF
--- a/book/CH10_JSONDataAPIs.adoc
+++ b/book/CH10_JSONDataAPIs.adoc
@@ -128,6 +128,7 @@ Note that by splitting these two APIs apart, you reduce the pressure to constant
 This is the key advantage of splitting your Data API from your Hypermedia API.
 
 ((("REST API")))
+
 .JSON Data APIs vs JSON "`REST`" APIs
 ****
 Unfortunately, today, for historical reasons, what we are calling JSON Data APIs are often referred to as


### PR DESCRIPTION
It was displaying the dot.

# Before

![image](https://github.com/bigskysoftware/hypermedia-systems/assets/20454870/d352ff0e-f88b-4446-b1d9-9c24a6394aa2)

# After

![image](https://github.com/bigskysoftware/hypermedia-systems/assets/20454870/e14d488b-e10c-4ccd-9408-b44914367ac0)
