### PR TITLE
Mention Versioning Issues in Hypermedia Applications that use Fragments

### DIFF
--- a/book/CH02_ComponentsOfAHypermediaSystem.adoc
+++ b/book/CH02_ComponentsOfAHypermediaSystem.adoc
@@ -760,7 +760,7 @@ would see the new HTML, display it properly, and allow users to select whatever 
 again, the uniform interface of REST has proven to be extremely flexible: despite a potentially radically new layout
 for our hypermedia API, clients continue to work.
 
-An important fact emerges from this:  due to this flexibility, hypermedia APIs _do not have the versioning headaches
+An important fact emerges from this:  due to this flexibility, hypermedia APIs _have fewer of the versioning headaches
 that JSON Data APIs do_.
 
 Once a Hypermedia-Driven Application has been "`entered into`" (that is, loaded through some entry point URL), all functionality
@@ -768,6 +768,11 @@ and resources are surfaced through self-describing messages.  Therefore, there i
 the client: the client simply renders the hypermedia (in this case HTML) and everything works out.  When a change occurs,
 there is no need to create a new version of the API: clients simply retrieve updated hypermedia, which encodes the new
 operations and resources in it, and display it to users to work with.
+
+_Caveat:_ there are still some temporary state inconsistencies possible when the updated hypermedia is only a fragment
+that is integrated into the existing state representation on the client, because the fragment might have implicit dependencies
+on the existing state on the client that could happen to not being satisfied after a server application update.
+There are ways to mitigate these cases.
 
 === Layered System
 

--- a/book/CH10_JSONDataAPIs.adoc
+++ b/book/CH10_JSONDataAPIs.adoc
@@ -105,7 +105,7 @@ and expect certain end points to behave in certain ways.
 | There is no need to remain stable over time: all URLs are discovered via HTML responses, so you can be much more aggressive in changing the shape of a hypermedia API.
 
 | It must be versioned: related to the first point, when you do make a major change, you need to version the API so that clients that are using the old API continue to work.
-| Versioning is not an issue, another strength of the hypermedia approach.
+| Versioning is less of an issue, another strength of the hypermedia approach. There are still some cases where clients can get into an inconsistent state when having an older application version open in the browser and fetching an html partial from a newer application version. The fetched endpoint might no longer exist, or return a html fragment that has dependencies on the surrounding DOM like referencing not existing `id`s or css classes. There are ways to mitigate these issues, and they happen less often because of the MPA approach where the full page is often reloaded.
 
 | It should be rate limited: since data APIs are often used by other clients, not just your own internal web application, requests should be rate limited, often by user, in order to avoid a single client overloading the system.
 | Rate limiting probably isn't as important beyond the prevention of Distributed Denial of Service (DDoS) attacks.


### PR DESCRIPTION
I'm opening this PR to start a discussion of versioning issues that can happen in hypermedia applications and when using htmx for fetching fragments. I feel this issue is neglected in the documentation and should be represented in a balanced way, ideally with examples on how to mitigate the issues.

Examples on when an inconsistent state could happen aways assume that the client browser loaded a full htmx page, then a server application update is deployed, and then the client executes some action that loads a fragment into the dom somewhere:

* Example 1: a loaded fragment references html elements outside of the fragment that have been added in an application update on the server, but are not yet contained in the browser dom.
* Example 2: a loaded fragment references css classes that have been updated or added in an application update on the server
* Example 3: an endpoint for fetching a fragment might have been removed in an application update on the server, but is still referenced in htmx element attributes in the browser dom.

Even if these cases are rare (depends on the number of users and deployment frequency), it would be great to give devs  heads-up on potential issues.