### PR TITLE
Fix typo "we can we can" to "we can"

### DIFF
--- a/book/CH09_ScriptingInAHypermediaApplication.adoc
+++ b/book/CH09_ScriptingInAHypermediaApplication.adoc
@@ -1298,7 +1298,7 @@ arguments `$el`, which is the Alpine syntax for getting `"the current element`" 
 the exact configuration we want for our dialog.
 
 If the user confirms the action, a `confirmed` event will be triggered on the button.  This means that we can go back
-to using our trusty htmx attributes!  Namely, we can move `DELETE` to an `hx-delete` attribute, and we can we can use
+to using our trusty htmx attributes!  Namely, we can move `DELETE` to an `hx-delete` attribute, and we can use
 `hx-target` to target the body.  And then, and here is the crucial step, we can use the `confirmed` event that is
 triggered in the `sweetConfirm()` function, to trigger the request, but adding an `hx-trigger` for it.
 


### PR DESCRIPTION
Fixes #131