### PR TITLE
Fix typo: remove extra closing curly brace

### DIFF
--- a/book/CH07_ADynamicArchiveUIWithhtmx.adoc
+++ b/book/CH07_ADynamicArchiveUIWithhtmx.adoc
@@ -353,7 +353,7 @@ Let's update our progress bar to have the proper ARIA roles and values:
 <div class="progress">
     <div class="progress-bar"
          role="progressbar" <1>
-         aria-valuenow="{{ archiver.progress() * 100}}}" <2>
+         aria-valuenow="{{ archiver.progress() * 100}}" <2>
          style="width:{{ archiver.progress() * 100 }}%"></div> <1>
 </div>
 ----


### PR DESCRIPTION
I suspect there might be an extra closing curly brace here.